### PR TITLE
Z Js documentation fixes

### DIFF
--- a/CONTRIBUTION.MD
+++ b/CONTRIBUTION.MD
@@ -1,11 +1,11 @@
 # This is how  this works in a nutshell
 
-You clone this repository, look around the markdown files around different directories in project, most include what's included and what is missing yet, you can start from there or read the readme.md file with overview of the framework roadmap on a high level.
+You clone this repository, look at the markdown files in different directories in the project, and see what's included and what is missing. You can start from there or read the README.md file, which provides a high-level overview of the framework roadmap.
 
-Once you done picking something you would like to work on, do it, create a branch off main branch, push to it and then make a pull request, we will review it in no time and merge it in if it's ok, and that's it.
+Once you have picked something you would like to work on, do it. Create a branch off the main branch, push to it, and then make a pull request. We will review it in no time and merge it in if it's okay, and that's it.
 
-Except z.js file and a few others, most files have where they belong in subsquent project directories so don't mind some redudant files in some directories for now, most will be removed soon, especially those in experiments!
+Except for the Z.Js file and a few others, most files are where they belong in subsequent project directories, so I don't mind some redundant files in some directories for now. Most will be removed soon, especially those in experiments!
 
-with that said, welcome on board, just keep an eye on how we naming things and how project's structured, we quite want to stay consistent, thank you!
+That said, welcome on board. Just keep an eye on how we name things and how the project is structured. We want to stay consistent. Thank you!
 
-Am Kizz by the way, nice to have you interested in this!
+I’m Kizz, by the way. It's nice to have you interested in this!

--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 # 🔥 Z.Js Framework (v0.0.3)
 
-The literally low overhead js framework!
+The literally low overhead Js framework!
 
 ## 🤖 Why Another Framework? Why Not, Listen Up
 
-As everyone is running for meta frameworks, server side rendering and whole new stuff out there in js frameworks ecosystem some of us got faded, frontend is hard, why make it harder with bloat and more mental overhead on devs? #DevsBrainsMatter
+As everyone is running for meta frameworks, server-side rendering, and all the new stuff out there in the Js frameworks ecosystem, some of us got fed up. The frontend is hard, so why make it harder with bloat and more mental overhead on devs? #DevsBrainsMatter
 
-so, I needed something very simple but can make a plain html, css and js project have a modern like developer experience and be scalable and yet has the power of single page applications (SPAs) or not to say, reactive applications.
+So, I needed something very simple that could make a plain HTML, CSS, and Js project have a modern developer experience, be scalable, and yet have the power of single-page applications (SPAs) or, not to say, reactive applications.
 
-Nothing fancy, something to bring that ease feeling when you just go vanilla using the bare minimums but not less powerful or make you repeat your implementations or copy paste code as you do in vanilla projects due to lack of compose-ability and components model, these are things we could solve without becoming complex and we instead capitalize on intuitve architecture, native web platform features and principles instead of a bunch of libs, meta frameworks, build tools, and server sh*t that newer devs are even not familiar with usually.
+Nothing fancy, something to bring that easy feeling when you just go vanilla, using the bare minimums, but not less powerful having to repeat your implementations or copy-paste code as you do in vanilla projects due to lack of compose-ability and components model, these are things we could solve without becoming complex. We instead capitalise on intuitive architecture, native web platform features and principles instead of a bunch of libs, meta frameworks, build tools, and server sh*t that newer devs are not even familiar with usually.
 
-> So after months of work, and learning, z js framework is the fruit of the efforts to make a simpler build step less js framework that trades all shinny stuff for simplicity and low mental overhead on devs, your tired of having to learn and always play catch up on new framework features just to make a simple app? try Z.Js!
+> So, after months of work and learning, the Z Js framework is the fruit of the efforts to make a more straightforward, step-less Js framework that trades all the shiny stuff for simplicity and low mental overhead on developers. Are you tired of having to learn and always play catch-up on new framework features just to make a simple app? Try Z Js!
 
-work in progress and calling on all those who feel like modern js frameworks have become so bloated, come contribute and we make this awesome, of course no shinny features allowed, z doesn't plan to included server side rendering, or related stuff, just do it old way, let your backend do it's job, and here we handle frontend side, this is not another one size fits all thing, this is a client side framework inspired by frameworks like react but not like them or another fullstack ferry, humbly it's just meant to be used for frontend only and that's all!
+This is a work in progress and calling on all those who feel like modern js frameworks have become so bloated to contribute to Z, and we will make this awesome; of course, no shiny features allowed, Z doesn't plan to include server-side rendering or related stuff, just do it the old way, let your backend do its job, and here we handle frontend side, this is not another one size fits all thing, this is a client-side framework inspired by frameworks like react but not like them or another full-stack ferry, humbly it's just meant to be used for frontend only, and that's all!
 
 ## Roadmap And Features If You Like To Contribute
 
 - ✅ Define framework usage and semantic basics
 - ✅ Create a custom state management mechanism
 - ✅ Create a simple way to persist state -- just use local storage or web storage
-- ✅ Create a custom events driven system for reactive UI updates
-- ✅ Create main Z binding layer to bring everything together
+- ✅ Create a custom events-driven system for reactive UI updates
+- ✅ Create a main Z binding layer to bring everything together
 - ✅ Create UI templating and styling foundations
 - ✅ Handle single page application model and routing
 - ✅ Handle automatic re-rendering on state change
@@ -32,13 +32,13 @@ work in progress and calling on all those who feel like modern js frameworks hav
 - 🔳 Improve documentation and provide more examples
 - 🔳 Introduce Js doc and ship this for massive adoption!
 
-what else?
+What else?
 
 ## 🤣 How it works? Yes It Works
 
 First things first, here is what you need to get started.
 
-1. Z js framework
+1. Z Js framework
 
 you can install it with command below
 
@@ -52,18 +52,18 @@ or use a cdn link directly in your html file
 <script src="https://cdn.jsdelivr.net/npm/z-js-framework@0.0.3/dist/z.js"></script>
 ```
 
-or for ninjas, grab the z.js script file from z js github repo in dist directory and include it in your project.
+Or for the ninjas, grab the z.js script file from Z.Js github repo in dist directory and include it in your project.
 
 2. Some static file server, optional but (recommended)
 
-Honestly, you gonna need some tooling to have the best experince but not mandatory
+Honestly, you gonna need some tooling to have the best experience, but it's not mandatory.
 
-💡 TIP: Use vite to run your project, run `npm i -g vite` to install vite globally and then run `vite dev` in your project root directory to start a dev server. And that's if you familiar with vite and want an easy start but can also just get the vscode extension [live server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer)
- and just run live sever on the html file there, like, any or those options would do just fine. you don't need a full flenged server for z to work, you just need to serve your artifacts over http that's all, otherwise the browser will be very angry with you and might refuse to show your stuff.
+💡 TIP: Use vite to run your project, run `npm i -g vite` to install vite globally and then run `vite dev` in your project root directory to start a dev server. And that's if you are familiar with vite and want an easy start but can also just get the VS Code extension [live server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer)
+ and just run a live server on the HTML file there. Any of those options would do just fine. You don't need a full-fledged server for z to work; you just need to serve your artifacts over HTTP, and that's all. Otherwise, the browser will be very angry with you and might refuse to show your stuff.
 
- 3. Vscode Extension (recommended)
+ 3. VS Code Extension (recommended)
 
-This is not a must, but I must tell you that z js uses javaScript template literals even for templating or crafting your UI for example:
+This is not a must, but I must tell you that Z Js uses JavaScript template literals even for templating or crafting your UI, for example:
 
 ```html
 import { html } from 'z.js'
@@ -72,11 +72,11 @@ let name = 'Kizz'
 let greetElement = html`<h1>Hello there, ${name}</h1>`
 ```
 
-now as you can see, it's pretty easy, just put your stuff in backticks, but we know the IDE won't highlight that as html but as a normal string, so for best experience and auto completions to make it feel like real html, get this exension [Inline HTML](https://marketplace.visualstudio.com/items?itemName=pushqrdx.inline-html) as it  will highlight them and give you some auto completions here and there, as we wait to work on our own z.js vscode extension, you can use that extension and it will work just fine with z.js. or if you want, just don't use it, its still fine!
+Now, as you can see, it's pretty easy: just put your stuff in backticks, but we know the IDE won't highlight that as HTML but as a normal string, so for the best experience and auto completions to make it feel like real HTML, get this extension [Inline HTML](https://marketplace.visualstudio.com/items?itemName=pushqrdx.inline-html) as it will highlight them and give you some auto completions here and there, as we wait to work on our own Z.Js VS Code extension, you can use that extension and it will work just fine with Z.Js. If you want, just don't use it; it's still fine!
 
-4. Last thing you need, is well guess it... you just need to write some javaScript code, and that's it.
+4. The last thing you need is... well, guess it... you just need to write some JavaScript code, and that's it.
 
-otherwise here is an example of how it works in great details, these are the official docs for now hehe, so pay attention, start by seting up your routes, in like a main.js or index.js file, whatever your app entry point file is...
+Otherwise, here is an example of how it works in great detail. These are the official docs for now, hehe, so pay attention. Start by setting up your routes in a main.js or index.js file, whatever your app entry point file is...
 
 > ✅ Routing
 
@@ -110,7 +110,7 @@ const routes = [
 render(root, routes);
 ```
 
-Then have some index html file which can act as the entry point of your application in the browser, it can look like this, no magic just a simple html file with a script tag pointing to your index.js file with type module attribute to tell broswer that it's module that can import other js files, otherwise in there you can do normal stuff like add a style tag if you like, just make sure the there's an element wit root id so that's where z will render the app as seen in first step above.
+Then, have an index HTML file that can act as the entry point for your application in the browser. It can look like this: no magic, just a simple HTML file with a script tag pointing to your index.js file with a type module attribute to tell the browser that it's a module that can import other JS files; otherwise, in there, you can do normal stuff like add a style tag if you like, just make sure the there's an element with root id so that's where z will render the app as seen in the first step above.
 
 ```html
 <!DOCTYPE html>
@@ -131,7 +131,7 @@ Then have some index html file which can act as the entry point of your applicat
 </html>
 ```
 
-Now, let's have a look at a z js component, a simple re-usable button component, it can be found in `example/components/button.js` and here is how it's implemented,
+Now, let's have a look at a Z Js component, a simple re-usable button component. It can be found in `example/components/button.js` and here is how it's implemented.
 
 > ✅ Components
 
@@ -166,13 +166,13 @@ export const Button = (children, setCount) => {
 
 ```
 
-ohh so you wondering what's happening, don't freak, let me explain:
+Ohh, so you are wondering what's happening? Don't freak, let me explain:
 
-1. first we import `css` and `html` from z.js, `css` is a function that takes a css template literal and returns a class name that you can use on your class attribute, it automatically creates those styles you define on that class with css tag function and makes sure they not recreated if they have not changed, it's like a builtin css-in-js solution, just write css, z will handle the rest, and then simillary the `html` is a function that takes a template literal and returns a html element out of it, you can use it to render your components, it returns a normal dom element with all events binded, like onclick event in this example.
-2. since these are just literals, we use `${__expression__}` syntax to interpolate the values, in this case we are interpolating the value of `children` and `setCount` which are the props passed to the component, and we are also interpolating the `clickButton` function which is the event handler for the button.
-3. we then export our Button function or component for re-usablity, that's it.
+1. First, we import `css` and `html` from z.js, `css` is a function that takes a CSS template literal and returns a class name that you can use on your class attribute. It automatically creates those styles you define on that class with css tag function and makes sure they are not recreated if they have not changed. It's like a builtin css-in-js solution. Just write CSS, z will handle the rest, and then similarly, the `html` is a function that takes a template literal and returns an HTML element out of it. You can use it to render your components, and it returns a normal dom element with all events bound, like onclick event in this example.
+2. Since these are just literals, we use `${__expression__}` syntax to interpolate the values; in this case, we are interpolating the value of `children` and `setCount`, which are the props passed to the component, and we are also interpolating the `clickButton` function which is the event handler for the button.
+3. We then export our Button function or component for re-usability; that's it.
 
-congs, you have just created your first z js component, now let's use it in a page, let's see how a home page with a button looks like, along some other 2 concepts, state and routing.
+Congratulations! You have just created your first Z Js component. Now, let's use it on a page. Let's see how a home page with a button looks, along with some other concepts, state and routing.
 
 > ✅ State Management
 
@@ -215,21 +215,21 @@ export default function Home() {
 
 ```
 
-well what's happening here? let's try to understand the code above,
+Well, what's happening here? let's try to understand the code above.
 
-1. we again import different stuff from z js framework, they're like hooks or utility functions each doing a well defined thing.
-2. we import the Button component from components directory, we can also import other components from other directories, it's just a convention to keep all your components in a components directory. We already saw how such component is made in previous steps!
-3. since we already know about the html and css functions now, let's look at the new ones here, useState and useEffect, these are much inspired by those of react, but make no mistake they're quite different in how they work, this is not react!
-4. the useState returns the state object and a state setter, eg. count and setCount, the state object has 2 properties that you can use for now, the value and cuerent, the value is the current value of the state, the current is a function that returns the current value of the state, so you can use it to get the current value of the state, and the setter is a function that takes a new value and updates the state, so you can use it to update the state. The state setter is useful when you want to update the state from a function, or you want to update the state from a child component. While the current function on the state object is useful when you want to get the current value of the state from a child component or in a series of comonent and state lifecycle, basically in useffects use state.current() to access state's current value not just state.value, you will be good.
-5. the useEffect is a function that takes a function and an array of state object dependencies, it's called when the dependencies change, it's called after the component is rendered, so you can use it to react to state changes, you can also use it to fetch data from an api upon some change of state, or do any other side effects, but make no mistake, unlike that of react, this one only runs when the state changes, it's not run on render of component, it's like an event listener which only happens when something happens say change of state in this case, otherwise if the an empty state dependecies array is provided, the provided function is run only once and for all on component load. Otherwise it would rerun this function everytime any of the provided state dependecy objects change or never if they never change!
-6. notice how we manually select the parts we want to update on state change from our home element and change it's inner html, real dom manipulation, the framework doesn't handle this for you as of now, you update what you want to update as you see fit, just like you would in a vanilla js, this is just a bit simplified but not a replacement.
-7. notcie how we use state.current() inside the useEffect, this ensures we get the latest value of this state object, otherwise state.value would be the old value of the state object, which would be the value of the state object at the time the component was rendered.
-8. state and state setters can be passed to child components as you see how setCount is being passed to Button component.
-9. unlike vanilla js literals here we can define our literals and attach events all at once, it's like jsx + template literals = jsx literals kind of, you see we attach the onChange handler on the input, and we do this by directly referencing the handleInput function, under the hood z js will create a real dom element out of this template and attach this as it should be, given in it's there in the component scope, or passed as an argument.
-10. all component or page functions in z return the created element, thats how we are able to reuse them and render them in the dom.
+1. We again import different stuff from the Z Js framework. These are like hooks or utility functions, each doing a well-defined thing.
+2. We import the Button component from the components directory. We can also import other components from other directories; it's just a convention to keep all your components in a components directory. We already saw how such a component is made in previous steps!
+3. Since we already know about the HTML and CSS functions, let's look at the new ones here: useState and useEffect. These are much inspired by those of React, but make no mistake—they're quite different in how they work. This is not React!
+4. The useState returns the state object and a state setter, e.g. count and setCount. The state object has 2 properties that you can use for now: the value and current. The value is the current value of the state, the current is a function that returns the current value of the state, so you can use it to get the current value of the state, and the setter is a function that takes a new value and updates the state, so you can use it to update the state. The state setter is useful when you want to update the state from a function or you want to update the state from a child component. While the current function on the state object is useful when you want to get the current value of the state from a child component or in a series of component and state lifecycle, basically in useffect use state.current() to access state's current value, not just state.value, you will be good.
+5. The useEffect is a function that takes a function and an array of state object dependencies. It's called when the dependencies change, and it's called after the component is rendered, so you can use it to react to state changes. You can also use it to fetch data from an API upon some change of state or do any other side effects, but make no mistake. Unlike react, this one only runs when the state changes. It's not run on render of component. It's like an event listener, which only happens when something happens, say, a change of state in this case. Otherwise, if an empty state dependencies array is provided, the provided function is run only once and for all on component load. Otherwise, it would rerun this function every time any of the provided state-dependent objects change or never if they never change!
+6. Notice how we manually select the parts we want to update on state change from our home element and change its inner HTML. This is real DOM manipulation. The framework doesn't handle this for you as of now. You update what you want to update as you see fit, just like you would in vanilla JS. This is just a bit simplified, but not a replacement.
+7. Notice how we use state.current() inside the useEffect. This ensures we get the latest value of this state object; otherwise, state.value would be the old value of the state object, which would be the value of the state object at the time the component was rendered.
+8. State and state setters can be passed to child components as you see how setCount is being passed to the Button component.
+9. Unlike vanilla js literals here we can define our literals and attach events all at once, it's like jsx + template literals = jsx literals kind of, you see we attach the onChange handler on the input, and we do this by directly referencing the handleInput function, under the hood z js will create a real dom element out of this template and attach this as it should be, given in it's there in the component scope, or passed as an argument.
+10. All component or page functions in z return the created element, thats how we are able to reuse them and render them in the dom.
 
-all most that's all of z as of now, just one last thing though...
-this is how you link between pages,
+Almost that's all of Z as of now. Just one last thing, though...
+This next part is how you link between pages.
 
 > ✅ Navigation
 
@@ -258,15 +258,15 @@ export default function Layout() {
 
 ```
 
-so here we doing a few things, building on old concepts, we import the useRouter function from z js, we use it to get the getParam function, this function takes a key as an argument and returns the value of the key in the url, in this case we are getting the blogId from the url, we log it to the console, and then we return the template, we have a div with links to other pages, and a main element with id content, this is where we will render the dynamic content view.
+So here we are doing a few things. Building on old concepts, we import the useRouter function from Z Js, and we use it to get the getParam function; this function takes a key as an argument and returns the value of the key in the URL. In this case, we are getting the blogId from the URL, we log it to the console, and then we return the template. We have a div with links to other pages and a main element with id content, and this is where we will render the dynamic content view.
 
-1. we use z-link to create links to other pages, it's a z js custom element that works with the router to route between pages, you pass the target attribute to it, which is the id of the element you want to render the content in, in this case we are rendering the content in the main element with id content.
-2. or  the to attribute to it, which is the url you want to route to, in this case we are routing to the about page or home page.
-3. normal a anchor tag links work just fine, they will route to the url you pass them as normal as they should.
+1. We use z-link to create links to other pages. It's a Z Js custom element that works with the router to route between pages. You pass the target attribute to it, which is the ID of the element in which you want to render the content. In this case, we are rendering the content in the main element with id content.
+2. Or the to attribute to it, which is the URL you want to route to. In this case we are routing to the about page or home page.
+3. Normal a anchor tag links work just fine, they will route to the URL you pass them as normal as they should.
 
 ## ♻️ Reactivity
 
-As with many modern frameworks, they are able to automatically re-render the app UI when state changes, and they do this in kinda different ways, usually using the virtual dom to make sure only minimum changes are applied to the real dom, this is way better and more efficient than just saying element.innerHtml = newHtml, but then z is just real dom, we have no virtual dom, so you either have to do this step manually inside a useEffect or we reached out to some great library [Morphdom](https://github.com/patrick-steele-idem/morphdom) to enable us do this in a smart way but with real dom not virtual dom. You don't have to do anything on your end, you just wrapp your component literal in a callback in our reactive function like below and it will automatically reflect changes on state change, so cool right, here is an example:
+As with many modern frameworks, they are able to automatically re-render the app UI when the state changes, and they do this in kinda different ways, usually using the virtual dom to make sure only minimum changes are applied to the real dom. This is way better and more efficient than just saying element.innerHtml = newHtml, but then z is just real dom. We have no virtual dom, so you either have to do this step manually inside a useEffect or we reached out to some great library [Morphdom](https://github.com/patrick-steele-idem/morphdom) to enable us to do this in a smart way but with real dom, not virtual dom. You don't have to do anything on your end; you just wrap your component literal in a callback in our reactive function like below, and it will automatically reflect changes on state change. So cool, right? Here is an example:
 
 > ✅ Reactivity
 
@@ -289,7 +289,7 @@ export default function SomeComponent() {
 }
 ```
 
-Up above, the username will always change to new value as user types into the input.
+Up above, the username will always change to a new value as the user types into the input.
 
 ## 🗃️ Hooks And Utilities
 
@@ -328,14 +328,14 @@ function fetchContent() {
 }
 ```
 
-That there shows loading and then bingo, shows the content.
+That shows loading, and then bingo shows the content.
 
 ## 😇 You want more?
 
-come on more stuff coming, and if you reached all the way here, your really a sumurai now, you can start using z js to build your next app, see the examples folder for some examples, as we prepare more docs later, but that's it for now, that's z js framework, let's get building!
+Come on, more stuff is coming, and if you reach all the way here, you are really a samurai now. You can start using Z Js to build your next app. See the examples folder for some examples, as we prepare more docs later, but that's it for now, that's Z Js framework, let's get building!
 
-More documentation and example of common use cases will be coming soon, help contribute!
+More documentation and examples of common use cases will be coming soon. Help contribute!
 
 ## 👾 What Next?
 
-Well this is still work in progress, am working on it in my little free time, so if you have other ideas or what, reach out to me at [hssnkizz@gmail.com](hssnkizz@gmail.com) or read [Contribution Guide](./CONTRIBUTION.MD) to get started on how things work and the whole project plan and roadmap!
+Well, this is still work in progress. I am working on it in my little free time, so if you have other ideas or what, reach out to me at [hssnkizz@gmail.com](hssnkizz@gmail.com) or read [Contribution Guide](./CONTRIBUTION.MD) to get started on how things work and the whole project plan and roadmap!


### PR DESCRIPTION
Grammatical fixes for README and CONTRIBUTION.md

This pull request addresses various grammatical and stylistic issues in the README and CONTRIBUTION.md files:

README:
- Fixed capitalization inconsistencies (e.g. "js" to "Js", "css" to "CSS")
- Corrected spelling errors 
- Improved punctuation usage (added missing commas, periods)
- Enhanced readability by breaking up long sentences
- Corrected minor typos throughout the document

CONTRIBUTION.md:
- Improved overall structure and flow of the document
- Enhanced clarity by breaking up long sentences into shorter, more digestible ones
- Corrected grammatical errors and improved sentence structures
- Standardized capitalisation (e.g. "README.md", "Z.Js")
- Added missing punctuation and corrected existing punctuation
- Improved formatting for better readability

These changes improve the overall readability and professionalism of both documents, making it easier for users and potential contributors to understand the Z.JS framework, its features, and how to contribute to the project.